### PR TITLE
Fixed enums to Qt6 version

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -627,7 +627,7 @@ def tag_edit_keypress(self, evt, _old):
     if not isinstance(win, AddCards):
         return
     modifiers = evt.modifiers()
-    if modifiers == Qt.ControlModifier or modifiers == Qt.AltModifier or modifiers == Qt.MetaModifier:
+    if modifiers == Qt.KeyboardModifier.ControlModifier or modifiers == Qt.KeyboardModifier.AltModifier or modifiers == Qt.KeyboardModifier.MetaModifier:
         return
     index = get_index()
     if UI.frozen:

--- a/src/command_parsing.py
+++ b/src/command_parsing.py
@@ -670,7 +670,7 @@ def expanded_on_bridge_cmd(handled: Tuple[bool, Any], cmd: str, self: Any) -> Tu
     elif cmd == "siac-timer-elapsed":
         # timer has elapsed, show a modal
         d = TimerElapsedDialog(aqt.mw.app.activeWindow())
-        if d.exec_():
+        if d.exec():
             if d.restart is not None:
                 UI.js(f"startTimer({d.restart});")
 
@@ -824,7 +824,7 @@ def expanded_on_bridge_cmd(handled: Tuple[bool, Any], cmd: str, self: Any) -> Tu
         source = Reader.note.source
         tooltip("Opening external file:<br>" + source)
         try:
-            QDesktopServices.openUrl(QUrl(source, QUrl.TolerantMode))
+            QDesktopServices.openUrl(QUrl(source, QUrl.ParsingMode.TolerantMode))
         except:
             tooltip("Failed to open external file:<br>" + source)
 

--- a/src/dialogs/components.py
+++ b/src/dialogs/components.py
@@ -727,7 +727,7 @@ class NoteSelector(QWidget):
         list.resizeRowsToContents()
 
     def cb_clicked(self, ix, nid, state):
-        if state == Qt.Checked:
+        if state == Qt.CheckState.Checked:
             self.selected_ids.append(nid)
             self.selected_notes.append([n for n in self._current if n.id == nid][0])
         else:
@@ -737,4 +737,4 @@ class NoteSelector(QWidget):
         self.refresh()
 
     def cb_outer_clicked(self, cb):
-        cb.setChecked(not cb.checkState() == Qt.Checked)
+        cb.setChecked(not cb.checkState() == Qt.CheckState.Checked)

--- a/src/dialogs/editor.py
+++ b/src/dialogs/editor.py
@@ -587,7 +587,7 @@ class CreateTab(QWidget):
         tags = get_all_tags()
         if tags:
             completer = QCompleter(tags)
-            completer.setCaseSensitivity(Qt.CaseInsensitive)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
             self.tag.setCompleter(completer)
         tag_hbox.addWidget(self.tag)
         if self.parent.tag_prefill is not None:
@@ -1108,7 +1108,7 @@ class PriorityListModel(QStandardItemModel):
                 rem_btn.setStyleSheet("border: 1px solid darkgrey; border-style: outset; font-size: 10px; background: #313233; color: white; margin: 0px; padding: 3px;")
             else:
                 rem_btn.setStyleSheet("border: 1px solid black; border-style: outset; font-size: 10px; background: white; margin: 0px; padding: 3px;")
-            rem_btn.setCursor(Qt.PointingHandCursor)
+            rem_btn.setCursor(Qt.CursorShape.PointingHandCursor)
             rem_btn.setMinimumHeight(18)
             rem_btn.clicked.connect(functools.partial(self.parent.on_remove_clicked, self.item(row).data()))
 
@@ -1152,19 +1152,19 @@ class HTMLDelegate(QStyledItemDelegate):
 
         style = QApplication.style() if options.widget is None \
             else options.widget.style()
-        style.drawControl(QStyle.CE_ItemViewItem, options, painter)
+        style.drawControl(QStyle.ControlElement.CE_ItemViewItem, options, painter)
 
         ctx = QAbstractTextDocumentLayout.PaintContext()
 
-        if option.state & QStyle.State_Selected:
-            ctx.palette.setColor(QPalette.Text, option.palette.color(
-                QPalette.Active, QPalette.HighlightedText))
+        if option.state & QStyle.StateFlag.State_Selected:
+            ctx.palette.setColor(QPalette.ColorRole.Text, option.palette.color(
+                QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText))
         else:
-            ctx.palette.setColor(QPalette.Text, option.palette.color(
-                QPalette.Active, QPalette.Text))
+            ctx.palette.setColor(QPalette.ColorRole.Text, option.palette.color(
+                QPalette.ColorGroup.Active, QPalette.ColorRole.Text))
 
         textRect = style.subElementRect(
-            QStyle.SE_ItemViewItemText, options)
+            QStyle.SubElement.SE_ItemViewItemText, options)
 
         painter.translate(textRect.topLeft())
         painter.setClipRect(textRect.translated(-textRect.topLeft()))
@@ -1244,8 +1244,8 @@ class FlowLayout(QLayout):
 
         for item in self.itemList:
             wid = item.widget()
-            spaceX = self.spacing() + wid.style().layoutSpacing(QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Horizontal)
-            spaceY = self.spacing() + wid.style().layoutSpacing(QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Vertical)
+            spaceX = self.spacing() + wid.style().layoutSpacing(QSizePolicy.ControlType.PushButton, QSizePolicy.ControlType.PushButton, Qt.Orientation.Horizontal)
+            spaceY = self.spacing() + wid.style().layoutSpacing(QSizePolicy.ControlType.PushButton, QSizePolicy.ControlType.PushButton, Qt.Orientation.Vertical)
             nextX = x + item.sizeHint().width() + spaceX
             if nextX - spaceX > rect.right() and lineHeight > 0:
                 x = rect.x()

--- a/src/dialogs/importing/general_import.py
+++ b/src/dialogs/importing/general_import.py
@@ -34,10 +34,10 @@ class NoteImporterDialog(QDialog):
     ##########################################################################
 
     def choose_file_and_add_to_ignore_list(self):
-        self.choose_and_add_to_ignore_list(mode=QFileDialog.AnyFile)
+        self.choose_and_add_to_ignore_list(mode=QFileDialog.FileMode.AnyFile)
 
     def choose_dir_and_add_to_ignore_list(self):
-        self.choose_and_add_to_ignore_list(mode=QFileDialog.Directory)
+        self.choose_and_add_to_ignore_list(mode=QFileDialog.FileMode.Directory)
 
     def choose_and_add_to_ignore_list(self, mode):
         # todo: add ignored directories to settings and then load for future multiple use
@@ -49,7 +49,7 @@ class NoteImporterDialog(QDialog):
 
         self.file_dialog = QFileDialog(parent=self, directory=path)
         self.file_dialog.setFileMode(mode)
-        if self.file_dialog.exec_():
+        if self.file_dialog.exec():
             fileNames = QFileDialog.selectedFiles(self.file_dialog)
             if fileNames:
                 for file in fileNames:
@@ -127,7 +127,7 @@ class Ui_OrganiserDialog(object):
     def setupUi(self, OrganiserDialog):
         OrganiserDialog.setObjectName("OrganiserDialog")
         OrganiserDialog.resize(525, 536)
-        sizePolicy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Policy.Minimum)
+        sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(OrganiserDialog.sizePolicy().hasHeightForWidth())

--- a/src/dialogs/importing/quick_web_import.py
+++ b/src/dialogs/importing/quick_web_import.py
@@ -302,8 +302,8 @@ class QuickImportBrowserTabs(QTabWidget):
 
         self._add_tab()
         self.addTab(QWidget(), "+")
-        if self.tabBar().tabButton(1, QTabBar.RightSide) is not None:
-            self.tabBar().tabButton(1, QTabBar.RightSide).resize(0,0)
+        if self.tabBar().tabButton(1, QTabBar.ButtonPosition.RightSide) is not None:
+            self.tabBar().tabButton(1, QTabBar.ButtonPosition.RightSide).resize(0,0)
 
         self.currentChanged.connect(self._tab_clicked)
         self.tabCloseRequested.connect(self._tab_close)
@@ -440,11 +440,11 @@ class UrlInput(QLineEdit):
         self.cb = cb
         self.suggestions = []
         self.completer = QCompleter(self.suggestions, self)
-        self.completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self.completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
         self.setCompleter(self.completer)
 
     def keyPressEvent(self, e):
-        if e.key() == Qt.Key_Enter or e.key() == Qt.Key_Return:
+        if e.key() == Qt.Key.Key_Enter or e.key() == Qt.Key.Key_Return:
             self.cb()
             self._refresh_completer()
             e.accept()
@@ -456,7 +456,7 @@ class UrlInput(QLineEdit):
         if len(t) > 0 and not t in self.suggestions:
             self.suggestions.append(t)
             self.completer = QCompleter(self.suggestions, self)
-            self.completer.setCaseSensitivity(Qt.CaseInsensitive)
+            self.completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
             self.setCompleter(self.completer)
 
     def mousePressEvent(self, e):
@@ -471,7 +471,7 @@ class SuppressLineEdit(QLineEdit):
         QLineEdit.__init__(self, parent)
 
     def keyPressEvent(self, e):
-        if e.key() == Qt.Key_Enter or e.key() == Qt.Key_Return:
+        if e.key() == Qt.Key.Key_Enter or e.key() == Qt.Key.Key_Return:
             e.accept()
         else:
             QLineEdit.keyPressEvent(self, e)
@@ -501,8 +501,8 @@ class SearchBar(QWidget):
         self.input.textChanged.connect(self.on_search_forward)
         self.input.returnPressed.connect(self.on_search_forward)
 
-        QShortcut(QKeySequence.FindNext, self, activated=next_btn.animateClick)
-        QShortcut(QKeySequence.FindPrevious, self, activated=prev_btn.animateClick)
+        QShortcut(QKeySequence.StandardKey.FindNext, self, activated=next_btn.animateClick)
+        QShortcut(QKeySequence.StandardKey.FindPrevious, self, activated=prev_btn.animateClick)
         #QShortcut(QKeySequence(get_config_value(shortcuts.quickweb.search_on_page)), self.input, activated=self.close_sig)
 
     def signal_not_found(self):

--- a/src/dialogs/importing/quick_youtube_import.py
+++ b/src/dialogs/importing/quick_youtube_import.py
@@ -26,7 +26,7 @@ class QuickYoutubeImport(QDialog):
         vbox = QVBoxLayout()
 
         # Cancel and Okay Buttons
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
         self.button_box.accepted.connect(self.accept_clicked)
         self.button_box.rejected.connect(self.reject)
 
@@ -66,7 +66,7 @@ class QuickYoutubeImport(QDialog):
         image = QPixmap(320, 180)
 
         def _reset_yt_properties():
-            self.button_box.button(QDialogButtonBox.Ok).setEnabled(False)
+            self.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(False)
             self.last_yt_id = None
             self.label_title.setText("<b>Paste a Youtube video url</b>")
             self.label_author.setText("Youtube Channel")
@@ -122,7 +122,7 @@ class QuickYoutubeImport(QDialog):
             return
 
         self.set_youtube_url(lineedit_text, yt_id)
-        self.button_box.button(QDialogButtonBox.Ok).setEnabled(True)
+        self.button_box.button(QDialogButtonBox.StandardButton.Ok).setEnabled(True)
 
     def set_youtube_url(self, urlstring: str, yt_id: str):
         time = utility.text.get_yt_time(urlstring)

--- a/src/dialogs/postpone_dialog.py
+++ b/src/dialogs/postpone_dialog.py
@@ -29,7 +29,7 @@ class PostponeDialog(QDialog):
     """ Values can be 0 (later today), or 1+ (in x days) """
 
     def __init__(self, parent, note_id):
-        QDialog.__init__(self, parent, Qt.FramelessWindowHint)
+        QDialog.__init__(self, parent, Qt.WindowType.FramelessWindowHint)
         self.note_id    = note_id
         self.value      = 0    
         self.setup_ui()
@@ -75,7 +75,7 @@ class PostponeDialog(QDialog):
         self.layout.addWidget(self.later_rb)
 
         icon = "calendar_night" if state.is_nightmode() else "calendar"
-        pmap = QPixmap(utility.misc.get_web_folder_path() + f"icons/{icon}").scaled(QSize(13, 13), Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        pmap = QPixmap(utility.misc.get_web_folder_path() + f"icons/{icon}").scaled(QSize(13, 13), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
 
         # Tomorrow radio button + label
         t_hb = QHBoxLayout()

--- a/src/dialogs/queue_picker.py
+++ b/src/dialogs/queue_picker.py
@@ -664,7 +664,7 @@ class ScheduleMWidget(QWidget):
             item.setTextAlignment(Qt.AlignmentFlag.AlignTop)
             self.table.setItem(ix, 0, item)
             if ix == 0 and today_stmp == due_date:
-                self.table.item(ix, 0).setForeground(Qt.blue if not state.is_nightmode() else Qt.cyan)
+                self.table.item(ix, 0).setForeground(Qt.GlobalColor.blue if not state.is_nightmode() else Qt.GlobalColor.cyan)
                 self.table.item(ix, 0).setText("Today")
             elif (datetime.today().date() + timedelta(days=1)).strftime("%Y-%m-%d") == due_date:
                 self.table.item(ix, 0).setText(f"{pretty}\n(Tomorrow)")
@@ -1018,7 +1018,7 @@ class QueueWidget(QWidget):
     def selected(self):
         r = []
         for ix in range(self.t_view_left.rowCount()):
-            if self.t_view_left.cellWidget(ix, 0).layout().itemAt(0).widget().checkState() == Qt.Checked:
+            if self.t_view_left.cellWidget(ix, 0).layout().itemAt(0).widget().checkState() == Qt.CheckState.Checked:
                 r.append(self.t_view_left.item(ix, 1).data(Qt.ItemDataRole.UserRole))
         return r
 
@@ -1054,8 +1054,8 @@ class QueueWidget(QWidget):
             tooltip("Select some items first")
 
     def empty_clicked(self):
-        reply = QMessageBox.question(self, 'Empty Queue', "This will remove all items from the queue.<br> Are you sure?", QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+        reply = QMessageBox.question(self, 'Empty Queue', "This will remove all items from the queue.<br> Are you sure?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.Yes:
             empty_priority_list()
             self.refresh_queue_list()
             self.tabs.currentWidget().refresh()
@@ -1063,8 +1063,8 @@ class QueueWidget(QWidget):
     def shuffle_clicked(self):
         reply = QMessageBox.question(self, 'Shuffle Queue', """This will change the current order of all items in the queue.
                                             <br>Priorities and schedules will stay the same.<br>
-                                            Are you sure?<br>""".replace("\n", ""), QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+                                            Are you sure?<br>""".replace("\n", ""), QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.Yes:
             shuffle_queue()
             self.refresh_queue_list()
             self.tabs.currentWidget().refresh()
@@ -1073,8 +1073,8 @@ class QueueWidget(QWidget):
         reply = QMessageBox.question(self, 'Spread Priorities', """
                                             This will spread the current priorities between 1 and 100.<br>
                                             Are you sure?<br>
-                                            """.replace("\n", ""), QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+                                            """.replace("\n", ""), QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.Yes:
             spread_priorities()
             self.refresh_queue_list()
             self.tabs.currentWidget().refresh()
@@ -1083,8 +1083,8 @@ class QueueWidget(QWidget):
         reply = QMessageBox.question(self, 'Random Priorities', """
                                             This will change the priorities of all items to a random value between 1 and 100.<br>
                                             Are you sure?<br>
-                                            """.replace("\n", ""), QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if reply == QMessageBox.Yes:
+                                            """.replace("\n", ""), QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.Yes:
             assign_random_priorities()
             self.refresh_queue_list()
             self.tabs.currentWidget().refresh()
@@ -1125,7 +1125,7 @@ class QueueWidget(QWidget):
 
     def cb_outer_clicked(self, row):
         widget = self.t_view_left.cellWidget(row, 0).layout().itemAt(0).widget()
-        widget.setChecked(not widget.checkState() == Qt.Checked)
+        widget.setChecked(not widget.checkState() == Qt.CheckState.Checked)
 
 
     def display_note_modal(self, id):
@@ -1213,8 +1213,8 @@ class NoteList(QTableWidget):
 
     def del_btn_clicked(self, id):
 
-        reply = QMessageBox.question(self, 'Delete Note?', "This will irreversibly delete the chosen note. \nAre you sure?", QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel, QMessageBox.Cancel)
-        if reply == QMessageBox.Yes:
+        reply = QMessageBox.question(self, 'Delete Note?', "This will irreversibly delete the chosen note. \nAre you sure?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No | QMessageBox.StandardButton.Cancel, QMessageBox.StandardButton.Cancel)
+        if reply == QMessageBox.StandardButton.Yes:
             delete_note(id)
             if get_index() is not None:
                 get_index().deleteNote(id)

--- a/src/dialogs/schedule_dialog.py
+++ b/src/dialogs/schedule_dialog.py
@@ -42,7 +42,7 @@ class ScheduleDialog(QDialog):
 
         c_lbl = QLabel(self)
         c_icon   = "calendar_night.png" if state.is_nightmode() else "calendar.png"
-        c_pixmap  = QPixmap(utility.misc.get_web_folder_path() + f"icons/{c_icon}").scaled(QSize(35, 35), Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        c_pixmap  = QPixmap(utility.misc.get_web_folder_path() + f"icons/{c_icon}").scaled(QSize(35, 35), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
         c_lbl.setPixmap(c_pixmap)
         hbox    = QHBoxLayout()
         hbox.addStretch()

--- a/src/dialogs/setting_tabs/shortcut.py
+++ b/src/dialogs/setting_tabs/shortcut.py
@@ -179,7 +179,7 @@ class ManualShortcut(QDialog):
 
     def __call__(self):
         self.line_edit.setText(self.shortcut_item.current_shortcut)
-        self.exec_()
+        self.exec()
 
     def accept_clicked(self):
         # TODO: ugly, check for stupid user input
@@ -214,7 +214,7 @@ class GrabKeyDialog(QDialog):
         self.extra = None
         self.new_shortcut = ""
 
-        self.exec_()
+        self.exec()
 
 
     def setup_ui(self):
@@ -229,29 +229,29 @@ class GrabKeyDialog(QDialog):
         self.active += 1
 
         # some special keys
-        if evt.key() == Qt.Key_Return:
+        if evt.key() == Qt.Key.Key_Return:
             self.extra = "Return"
-        elif evt.key() == Qt.Key_Left:
+        elif evt.key() == Qt.Key.Key_Left:
             self.extra = "Left"
-        elif evt.key() == Qt.Key_Right:
+        elif evt.key() == Qt.Key.Key_Right:
             self.extra = "Right"
-        elif evt.key() == Qt.Key_Up:
+        elif evt.key() == Qt.Key.Key_Up:
             self.extra = "Up"
-        elif evt.key() == Qt.Key_Down:
+        elif evt.key() == Qt.Key.Key_Down:
             self.extra = "Down"
 
         # normal keys
         elif evt.key() > 0 and evt.key() < 127:
             self.extra = chr(evt.key())
-            if evt.key() == Qt.Key_Space:
+            if evt.key() == Qt.Key.Key_Space:
                 self.extra = "Space"
 
         # base keys
-        elif evt.key() == Qt.Key_Control:
+        elif evt.key() == Qt.Key.Key_Control:
             self.ctrl = True
-        elif evt.key() == Qt.Key_Alt:
+        elif evt.key() == Qt.Key.Key_Alt:
             self.alt = True
-        elif evt.key() == Qt.Key_Shift:
+        elif evt.key() == Qt.Key.Key_Shift:
             self.shift = True
 
 

--- a/src/dialogs/tag_chooser.py
+++ b/src/dialogs/tag_chooser.py
@@ -79,7 +79,7 @@ class TagChooserDialog(QDialog):
         tags = get_all_tags()
         if tags:
             completer = QCompleter(tags)
-            completer.setCaseSensitivity(Qt.CaseInsensitive)
+            completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
             self.tag.setCompleter(completer)
         vbox.addWidget(self.tag)
         if self.tag_string is not None:
@@ -117,9 +117,9 @@ class TagChooserDialog(QDialog):
             self.tag.setText(" ".join(existing))
 
     def tag_cb_changed(self, state):
-        self.tree.include_anki_tags = (state == Qt.Checked)
+        self.tree.include_anki_tags = (state == Qt.CheckState.Checked)
         self.tree.rebuild_tree()
-        update_config("notes.editor.include_anki_tags", state == Qt.Checked)
+        update_config("notes.editor.include_anki_tags", state == Qt.CheckState.Checked)
 
     def on_tag_sort_change(self, new_sort: str):
         self.tree.sort = new_sort.lower()

--- a/src/dialogs/timer_elapsed.py
+++ b/src/dialogs/timer_elapsed.py
@@ -28,7 +28,7 @@ class TimerElapsedDialog(QDialog):
     """ Dialog that is shown after the tomato timer finished. """
 
     def __init__(self, parent):
-        QDialog.__init__(self, parent, Qt.FramelessWindowHint)
+        QDialog.__init__(self, parent, Qt.WindowType.FramelessWindowHint)
 
         self.setModal(True)
         self.mw     = aqt.mw
@@ -43,7 +43,7 @@ class TimerElapsedDialog(QDialog):
 
         c_lbl = QLabel(self)
         c_icon   = "hourglass_night.png" if state.is_nightmode() else "hourglass.png"
-        c_pixmap  = QPixmap(utility.misc.get_web_folder_path() + f"icons/{c_icon}").scaled(QSize(35, 35), Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        c_pixmap  = QPixmap(utility.misc.get_web_folder_path() + f"icons/{c_icon}").scaled(QSize(35, 35), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
         c_lbl.setPixmap(c_pixmap)
         hbox    = QHBoxLayout()
         hbox.addStretch()

--- a/src/utility/misc.py
+++ b/src/utility/misc.py
@@ -309,7 +309,7 @@ def img_src_base_path():
 def qlabel_image(icon_name, w, h):
     """ Return a QLabel with the given icon as pixmap. """
     lbl     = QLabel()
-    pixmap  = QPixmap(get_web_folder_path() + f"icons/{icon_name}").scaled(QSize(w, h), Qt.KeepAspectRatio, Qt.SmoothTransformation)
+    pixmap  = QPixmap(get_web_folder_path() + f"icons/{icon_name}").scaled(QSize(w, h), Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
     lbl.setPixmap(pixmap)
     return lbl
 
@@ -339,9 +339,9 @@ def url_to_pdf(url, output_path, cb_after_finish = None):
 
     def save_pdf(finished):
         printer = QPrinter()
-        printer.setPageMargins(10, 10, 10, 10, QPrinter.Millimeter)
+        printer.setPageMargins(10, 10, 10, 10, QPrinter.Unit.Millimeter)
         printer.setPageSize(QPrinter.A3)
-        printer.setPageOrientation(QPageLayout.Portrait)
+        printer.setPageOrientation(QPageLayout.Orientation.Portrait)
         temp.page().printToPdf(output_path, printer.pageLayout())
 
     temp.loadFinished.connect(save_pdf)

--- a/src/utility/tag_tree.py
+++ b/src/utility/tag_tree.py
@@ -59,7 +59,7 @@ class TagTree(QTreeWidget):
         self.setMinimumWidth(220)
 
         if self.knowledge_tree:
-            self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+            self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
             self.setColumnCount(2)
             self.setHeaderLabels(["Item", "Deck"])
             self.setHeaderHidden(False)


### PR DESCRIPTION
I was helping out @khonkhortisan with some issues they were having and found various enums that are using the old Qt5 version. I quickly searched through the rest of the code base, but I might have missed some. I also changed some calls that were to `exec_()` to call `exec()` instead, as this is the new Qt6 method (see [here](https://www.riverbankcomputing.com/static/Docs/PyQt6/pyqt5_differences.html) for more details).

A few things that would throw errors that should now be fixed:
- From the main page toolbar `SIAC -> Import -> Youtube` would error.
- From the main page toolbar `SIAC -> Add-on Settings -> Shortcuts -> Manual` would error.
- From the main page toolbar `SIAC -> Queue Manager -> Shuffle / Spread Priorities / Randomize Priorities` would all error.
- Pressing X on a video note would error.
- And so on...