### PR TITLE
fix: fixed startup error from issue #18

### DIFF
--- a/src/markdown/util.py
+++ b/src/markdown/util.py
@@ -82,7 +82,7 @@ Constants you probably do not need to change
 """
 
 # Only load extension entry_points once.
-INSTALLED_EXTENSIONS = metadata.entry_points().get('markdown.extensions', ())
+INSTALLED_EXTENSIONS = metadata.entry_points(group="markdown", name="extensions")
 RTL_BIDI_RANGES = (
     ('\u0590', '\u07FF'),
     # Hebrew (0590-05FF), Arabic (0600-06FF),


### PR DESCRIPTION
It seems to have been from a change in the behaviour of metadata.entry_points, and presumably broke when that changed versions.
I just changed it to the current syntax.